### PR TITLE
장운서_Longest Palindormic Substring

### DIFF
--- a/TeamD/장운서_Longest Palindromic Substring.ts
+++ b/TeamD/장운서_Longest Palindromic Substring.ts
@@ -1,0 +1,36 @@
+function longestPalindrome(s: string): string {
+	const n = s.length
+	if (n < 2) return s
+
+	let start = 0,
+		end = 0
+
+	// [L, R]에서 좌우로 가능한 만큼 확장하여 최종 팰린드롬 구간을 반환
+	const expand = (L: number, R: number) => {
+		while (L >= 0 && R < n && s[L] === s[R]) {
+			L--
+			R++
+		}
+		// 탈출 시점에 L, R은 한 칸 넘어간 상태 → 실제 구간은 [L+1, R-1]
+		return [L + 1, R - 1] as const
+	}
+
+	for (let i = 0; i < n; i++) {
+		// 홀수 길이 중심
+		const [l1, r1] = expand(i, i)
+		// 짝수 길이 중심
+		const [l2, r2] = expand(i, i + 1)
+
+		// 더 긴 구간으로 갱신
+		if (r1 - l1 > end - start) {
+			start = l1
+			end = r1
+		}
+		if (r2 - l2 > end - start) {
+			start = l2
+			end = r2
+		}
+	}
+
+	return s.slice(start, end + 1)
+}


### PR DESCRIPTION
## 🧑‍💻 언어 및 제출 결과

- 사용 언어: `TypeScript`,
- 통과 여부:  ❌

## 🧠 풀이 설명

- 아예 모르겟던데요...
- 푸는 방법 자체가 머릿속에 안 떠올랏어요...
- 풀이 봐도 모르겠어서 일단 아래 풀이만 자세히 적어두겠습니다
구현 단계
예외 처리

길이 0~1이면 그대로 반환.

최장 구간 저장 변수

start, end로 현재까지 찾은 최장 팰린드롬의 시작/끝 인덱스를 저장.

확장 함수 정의

인자로 왼쪽/오른쪽 포인터 (L, R)를 받아,
두 문자가 같은 동안 좌우로 한 칸씩 넓히며 최대 구간을 찾음.

반복문을 빠져나오면 한 칸 넘쳤으니, 실제 팰린드롬은 [L+1, R-1].

모든 중심에 대해 확장

홀수 길이(중심이 문자 하나): (i, i)

짝수 길이(중심이 문자 사이): (i, i+1)

두 결과 중 더 긴 구간으로 start/end 갱신.

결과 반환

s.slice(start, end + 1) 반환(끝 인덱스 포함이므로 +1).

완성 코드 (주석 포함)
```ts
function longestPalindrome(s: string): string {
  const n = s.length;
  if (n < 2) return s;

  let start = 0, end = 0;

  // [L, R]에서 좌우로 가능한 만큼 확장하여 최종 팰린드롬 구간을 반환
  const expand = (L: number, R: number) => {
    while (L >= 0 && R < n && s[L] === s[R]) {
      L--; R++;
    }
    // 탈출 시점에 L, R은 한 칸 넘어간 상태 → 실제 구간은 [L+1, R-1]
    return [L + 1, R - 1] as const;
  };

  for (let i = 0; i < n; i++) {
    // 홀수 길이 중심
    const [l1, r1] = expand(i, i);
    // 짝수 길이 중심
    const [l2, r2] = expand(i, i + 1);

    // 더 긴 구간으로 갱신
    if (r1 - l1 > end - start) {
      start = l1; end = r1;
    }
    if (r2 - l2 > end - start) {
      start = l2; end = r2;
    }
  }

  return s.slice(start, end + 1);
}
```
작은 드라이런(“babad”)
i=0(‘b’): 홀수 중심 → “b”; 짝수 중심 → 없음

i=1(‘a’): 홀수 중심 확장하면 “bab” → 최장 갱신(start=0,end=2)

i=2(‘b’): 홀수 중심 확장하면 “aba” → 길이는 같아서 유지/또는 교체(정답은 여러 개 가능)

팁 & 주의
짝수 중심 (i, i+1)을 꼭 함께 확인해야 "bb" 같은 케이스를 잡습니다.

반환 시 slice(end + 1)로 자르도록 off-by-one 실수 주의.

시간복잡도 O(n²), 공간복잡도 O(1).

Map은 이 문제 핵심(구간 대칭)과 직접적 연관이 없어 보통 쓰지 않습니다.

## 📊 시간/공간 복잡도

> ✅ 어떠한 근거로 시간/공간 복잡도가 이렇게 나왔는지 설명해주세요.

> ⚡️ 풀이의 속도와 메모리 등을 캡쳐해서 올려주세요.

- 시간 복잡도: `O(n)`
- 공간 복잡도: `O(1)`

![example](../example.png)

## 📝 추가 설명 (선택)

- 고민했던 포인트가 있다면 간단히 적어주세요.

## 🙋‍♂️ 리뷰어에게

- 리뷰어가 보면 좋을 포인트, 질문, 궁금한 점 등을 작성해 주세요.
